### PR TITLE
v3

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -44,7 +44,10 @@ jobs:
           npm install webgpu-spd@1.0.0
           cp -r node_modules/webgpu-spd/dist docs/1.0.0/dist
           mkdir -p docs/2.x
-          cp -r dist docs/2.x/dist
+          npm install webgpu-spd@2.0.1
+          cp -r node_modules/webgpu-spd/dist docs/2.x/dist
+          mkdir -p docs/3.x
+          cp -r dist docs/3.x/dist
           cp -r demo docs/demo
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## [Unreleased]
 
+### Added
+
+- Add support for texture formats enabled by the device feature [texture-formats-tier1](https://www.w3.org/TR/webgpu/#texture-formats-tier1).
+
+### Changed
+
+- Use subgroup built-ins for downsampling by default if the device feature [subgroups](https://www.w3.org/TR/webgpu/#subgroups) is enabled.
+- Move texture format `bgra8unorm` out of `WebGPUSinglePassDownsampler::supportedFormats`.
+
+### Fixed
+
+- Fix handling of barriers for active workgroup counter.
+- Cast downsampling weight to concrete scalar type for average filter.
+- Fix minor typing issues.
+
+
 ## [v2.0.1] - 2024-06-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Use subgroup built-ins for downsampling by default if the device feature [subgroups](https://www.w3.org/TR/webgpu/#subgroups) is enabled.
 - Move texture format `bgra8unorm` out of `WebGPUSinglePassDownsampler::supportedFormats`.
+- If the texture format supports it, bind mip 6 as `'read-write'` storage texture instead of duplicating texture data in an extra buffer in case more than 6 mips are generated per pass. 
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [v3.0.0] - 2025-08-03
+
 ### Added
 
 - Add support for texture formats enabled by the device feature [texture-formats-tier1](https://www.w3.org/TR/webgpu/#texture-formats-tier1).
@@ -17,7 +19,6 @@
 - Fix handling of barriers for active workgroup counter.
 - Cast downsampling weight to concrete scalar type for average filter.
 - Fix minor typing issues.
-
 
 ## [v2.0.1] - 2024-06-20
 

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ npm install webgpu-spd
 
 ### From GitHub
 ```js
-import { WebGPUSinglePassDownsampler } from 'https://jolifantobambla.github.io/webgpu-spd/2.x/dist/index.js';
+import { WebGPUSinglePassDownsampler } from 'https://jolifantobambla.github.io/webgpu-spd/3.x/dist/index.js';
 ```
 
 ### From UNPKG
 ```js
-import { WebGPUSinglePassDownsampler } from 'https://unpkg.com/webgpu-spd@2.0.0/dist/index.js';
+import { WebGPUSinglePassDownsampler } from 'https://unpkg.com/webgpu-spd@3.0.0/dist/index.js';
 ```
 
 ## Usage

--- a/demo/index.html
+++ b/demo/index.html
@@ -93,8 +93,8 @@
     </div>
 
     <script type="module">
-        import { WebGPUSinglePassDownsampler, maxMipLevelCount } from '../2.x/dist/index.js';
-        
+        import { WebGPUSinglePassDownsampler, maxMipLevelCount } from '../3.x/dist/index.js';
+
         function makeCheckerboardTextureData(size, numChannels, tileSize = 16, offset = 0, scalarType = 'f32') {
             const data = new (scalarType === 'f32' ? Float32Array : scalarType === 'i32' ? Int32Array : Uint32Array)(size * size * numChannels);
             for (let i = 0; i < size * size; ++i) {

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -26,7 +26,7 @@ declare class SPDPassInner {
     private pipeline;
     private bindGroups;
     private dispatchDimensions;
-    constructor(pipeline: GPUComputePipeline, bindGroups: Array<GPUBindGroup>, dispatchDimensions: [number, number, number]);
+    constructor(pipeline: GPUComputePipeline, bindGroups: Array<GPUBindGroup>, dispatchDimensions: [GPUSize32, GPUSize32, GPUSize32]);
     encode(computePass: GPUComputePassEncoder): void;
 }
 /**
@@ -133,6 +133,10 @@ export interface SPDPrepareDeviceDescriptor {
      * Defaults to `Math.min(device.limits.maxStorageTexturesPerShaderStage, 12)`.
      */
     maxMipsPerPass?: number;
+    /**
+     * If true, disables all uses of subgroup built-ins by the downsampler even if the `'subgroups'` feature is enabled on the {@link device}.
+     */
+    disableSubgroups?: boolean;
 }
 /**
  * Returns the maximum number of mip levels for a given n-dimensional size.
@@ -149,10 +153,24 @@ export declare class WebGPUSinglePassDownsampler {
     private devicePipelines;
     /**
      * The set of formats supported by WebGPU SPD.
-     *
-     * Note that `bgra8unorm` is only supported if the device feature `bgra8unorm-storage` is enabled.
      */
-    readonly supportedFormats: Set<string>;
+    static readonly supportedFormats: Set<string>;
+    /**
+     * The set of additionally supported formats supported if the feature 'bgra8unorm-storage' is enabled.
+     */
+    static readonly supportedFormatsBgra8UnormStorage: Set<string>;
+    /**
+     * The set of additionally supported formats if the feature 'texture-formats-tier1' is enabled.
+     */
+    static readonly supportedFormatsTier1: Set<string>;
+    /**
+     * The set of formats that support read-write access.
+     */
+    static readonly supportedReadWriteFormats: Set<string>;
+    /**
+     * The set of formats that support read-write access if the feature 'texture-formats-tier2' is enabled.
+     */
+    static readonly supportedReadWriteFormatsTier2: Set<string>;
     /**
      * Sets the preferred device limits for {@link WebGPUSinglePassDownsampler} in a given record of limits.
      * Existing preferred device limits are either increased or left untouched.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webgpu-spd",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "webgpu-spd",
-      "version": "2.0.1",
+      "version": "3.0.0",
       "license": "MIT",
       "devDependencies": {
         "@webgpu/types": "^0.1.40",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,10 +33,11 @@
       "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -159,9 +160,9 @@
       "dev": true
     },
     "brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webgpu-spd",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "A port of AMD's Single Pass Downsampler for WebGPU",
   "type": "module",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 function makeShaderCode(outputFormat: string, filterOp: string = SPD_FILTER_AVERAGE, numMips: number, scalarType: SPDScalarType): string {
     const texelType = scalarType === SPDScalarType.I32 ? 'i32' : (scalarType === SPDScalarType.U32 ? 'u32' : 'f32');
     const useF16 = scalarType === SPDScalarType.F16;
-    
-    const filterCode = filterOp === SPD_FILTER_AVERAGE && !['f32', 'f16'].includes(texelType) ? filterOp.replace('* 0.25', '/ 4') : filterOp;
+
+    const filterCode = filterOp === SPD_FILTER_AVERAGE && !['f32', 'f16'].includes(texelType) ? filterOp.replace('* SPDScalar(0.25)', '/ 4') : filterOp;
 
     const mipsBindings = Array(numMips).fill(0)
         .map((_, i) => `@group(0) @binding(${i + 1}) var dst_mip_${i + 1}: texture_storage_2d_array<${outputFormat}, write>;`)
@@ -496,7 +496,7 @@ fn downsample(@builtin(local_invocation_index) local_invocation_index: u32, @bui
 
 const SPD_FILTER_AVERAGE: string = /* wgsl */`
 fn spd_reduce_4(v0: vec4<SPDScalar>, v1: vec4<SPDScalar>, v2: vec4<SPDScalar>, v3: vec4<SPDScalar>) -> vec4<SPDScalar> {
-    return (v0 + v1 + v2 + v3) * 0.25;
+    return (v0 + v1 + v2 + v3) * SPDScalar(0.25);
 }
 `;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1116,15 +1116,12 @@ export class WebGPUSinglePassDownsampler {
 
     /**
      * The set of formats supported by WebGPU SPD.
-     *
-     * Note that `bgra8unorm` is only supported if the device feature `bgra8unorm-storage` is enabled.
      */
     readonly supportedFormats: Set<string> = new Set([
         'rgba8unorm',
         'rgba8snorm',
         'rgba8uint',
         'rgba8sint',
-        'bgra8unorm', // if bgra8unorm-storage is enabled
         'rgba16uint',
         'rgba16sint',
         'rgba16float',
@@ -1137,6 +1134,42 @@ export class WebGPUSinglePassDownsampler {
         'rgba32uint',
         'rgba32sint',
         'rgba32float',
+    ]);
+
+    /**
+     * The set of additionally supported formats supported if the feature 'bgra8unorm-storage' is enabled.
+     */
+    readonly supportedFormatsBgra8UnormStorage: Set<string> = new Set([
+        'bgra8unorm',
+    ]);
+
+    /**
+     * The set of additionally supported formats if the feature 'texture-formats-tier1' is enabled.
+     */
+    readonly supportedFormatsTier1: Set<string> = new Set([
+        'r8unorm',
+        'r8snorm',
+        'r8uint',
+        'r8sint',
+        'rg8unorm',
+        'rg8snorm',
+        'rg8uint',
+        'rg8sint',
+        'r16unorm',
+        'r16snorm',
+        'r16uint',
+        'r16sint',
+        'r16float',
+        'rg16unorm',
+        'rg16snorm',
+        'rg16uint',
+        'rg16sint',
+        'rg16float',
+        'rgba16unorm',
+        'rgba16snorm',
+        'rgb10a2uint',
+        'rgb10a2unorm',
+        'rg11b10ufloat',
     ]);
 
     /**
@@ -1259,8 +1292,11 @@ export class WebGPUSinglePassDownsampler {
             console.warn(`[WebGPUSinglePassDownsampler::prepare]: no mips to create (numMips = ${numMips})`);
             return undefined;
         }
-        if (!this.supportedFormats.has(target.format)) {
-            throw new Error(`[WebGPUSinglePassDownsampler::prepare]: format ${target.format} not supported. (Supported formats: ${this.supportedFormats})`);
+        if (!(this.supportedFormats.has(target.format) ||
+            (device.features.has('bgra8unorm-storage') && this.supportedFormatsBgra8UnormStorage.has(target.format)) ||
+            ((device.features.has('texture-formats-tier1') || device.features.has('texture-formats-tier2')) && this.supportedFormatsTier1.has(target.format))))
+        {
+            throw new Error(`[WebGPUSinglePassDownsampler::prepare]: format ${target.format} not supported. (Supported formats: ${this.supportedFormats}, and ${this.supportedFormatsBgra8UnormStorage} (if 'bgra8unorm-storage' is enabled), and ${this.supportedFormatsTier1} (if 'texture-formats-tier1' is enabled))`);
         }
         if (target.format === 'bgra8unorm' && !device.features.has('bgra8unorm-storage')) {
             throw new Error(`[WebGPUSinglePassDownsampler::prepare]: format ${target.format} not supported without feature 'bgra8unorm-storage' enabled`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -637,13 +637,13 @@ export enum SPDFilters {
 }
 
 class SPDPassInner {
-    constructor(private pipeline: GPUComputePipeline, private bindGroups: Array<GPUBindGroup>, private dispatchDimensions: [number, number, number]) {}
+    constructor(private pipeline: GPUComputePipeline, private bindGroups: Array<GPUBindGroup>, private dispatchDimensions: [GPUSize32, GPUSize32, GPUSize32]) {}
     encode(computePass: GPUComputePassEncoder) {
         computePass.setPipeline(this.pipeline);
         this.bindGroups.forEach((bindGroup, index) => {
             computePass.setBindGroup(index, bindGroup);
         });
-        computePass.dispatchWorkgroups(...this.dispatchDimensions);
+        computePass.dispatchWorkgroups(this.dispatchDimensions[0], this.dispatchDimensions[1], this.dispatchDimensions[2]);
     }
 }
 
@@ -807,7 +807,7 @@ function sanitizeScalarType(device: GPUDevice, format: GPUTextureFormat, halfPre
     if (halfPrecision && texelType !== SPDScalarType.F32) {
         console.warn(`[sanitizeScalarType]: half precision requested for non-float format (${format}, uses ${texelType}), falling back to full precision`);
     }
-    return halfPrecision === true && !device.features.has('shader-f16') && texelType === SPDScalarType.F32 ? SPDScalarType.F16 : texelType;
+    return halfPrecision && !device.features.has('shader-f16') && texelType === SPDScalarType.F32 ? SPDScalarType.F16 : texelType;
 }
 
 class DevicePipelines {


### PR DESCRIPTION
### Added

- Add support for texture formats enabled by the device feature [texture-formats-tier1](https://www.w3.org/TR/webgpu/#texture-formats-tier1).

### Changed

- Use subgroup built-ins for downsampling by default if the device feature [subgroups](https://www.w3.org/TR/webgpu/#subgroups) is enabled.
- Move texture format `bgra8unorm` out of `WebGPUSinglePassDownsampler::supportedFormats`.
- If the texture format supports it, bind mip 6 as `'read-write'` storage texture instead of duplicating texture data in an extra buffer in case more than 6 mips are generated per pass. 

### Fixed

- Fix handling of barriers for active workgroup counter.
- Cast downsampling weight to concrete scalar type for average filter.
- Fix minor typing issues.